### PR TITLE
Add Mail Container to Docker-Compose

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -29,13 +29,26 @@ services:
     tty: true
     working_dir: /src
     ports:
-      - "3000:3000"
+      - "3003:3003"
     volumes:
       - ./client:/src
     env_file:
       - .env.dev
     command: >
       sh -c "npm install -g npm@latest && npm install && npm run dev"
+    depends_on:
+      - server
+      - db
+
+  mail:
+    container_name: mail
+    build: ./mail
+    stdin_open: true
+    tty: true
+    working_dir: /home/mailhog
+    ports:
+      - "1025:1025"
+      - "8025:8025"
     depends_on:
       - server
       - db

--- a/mail/Dockerfile
+++ b/mail/Dockerfile
@@ -1,0 +1,29 @@
+#
+# MailHog Dockerfile
+#
+
+FROM golang:alpine as builder
+
+# Install MailHog:
+RUN apk --no-cache add --virtual build-dependencies \
+    git \
+  && mkdir -p /root/gocode \
+  && export GOPATH=/root/gocode \
+  && go install github.com/mailhog/MailHog@latest
+
+FROM alpine:3
+# Add mailhog user/group with uid/gid 1000.
+# This is a workaround for boot2docker issue #581, see
+# https://github.com/boot2docker/boot2docker/issues/581
+RUN adduser -D -u 1000 mailhog
+
+COPY --from=builder /root/gocode/bin/MailHog /usr/local/bin/
+
+USER mailhog
+
+# WORKDIR /home/mailhog
+
+ENTRYPOINT ["MailHog"]
+
+# Expose the SMTP and HTTP ports:
+# EXPOSE 1025 8025

--- a/server/server/settings.py
+++ b/server/server/settings.py
@@ -102,7 +102,7 @@ AUTH_USER_MODEL = 'accounts.CustomUser'
 
 # EMAIL CONFIG
 EMAIL_BACKEND = "django.core.mail.backends.smtp.EmailBackend"
-EMAIL_HOST = "localhost"
+EMAIL_HOST = "172.21.0.4"
 EMAIL_PORT = "1025"
 EMAIL_HOST_USER = ""
 EMAIL_HOST_PASSWORD = ""


### PR DESCRIPTION
These changes will allow for use of an additional container that runs a development smtp email server via the 'mailhog' project. This email server is leveraged for user onboarding/account activation. Closes #5